### PR TITLE
Added handlers schema into api.xsd schema

### DIFF
--- a/vscode-plugin/synapse-schemas/api.xsd
+++ b/vscode-plugin/synapse-schemas/api.xsd
@@ -38,6 +38,25 @@
         </xs:annotation>
         <xs:sequence>
             <xs:element name="resource" type="APIResource" minOccurs="1" maxOccurs="unbounded"/>
+            <xs:element name="handlers" minOccurs="0">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="handler" minOccurs="0" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:sequence>
+                                    <xs:element name="property" minOccurs="0" maxOccurs="unbounded">
+                                        <xs:complexType>
+                                            <xs:attribute name="name" type="xs:string" use="required" />
+                                            <xs:attribute name="value" type="xs:string" use="required" />
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:sequence>
+                                <xs:attribute name="class" type="xs:string" use="required" />
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
         </xs:sequence>
         <xs:attributeGroup ref="monitoringAspect"/>
         <xs:attribute name="name" type="xs:string" use="required"/>


### PR DESCRIPTION
Added handlers schema into api xsd schema

## Purpose
> Handlers which are used e.g. for securing Rest API are not validated by api.xsd schema
``` xml
   <handlers>
       <handler class="org.wso2.handler.SimpleOauthHandler"/>
   </handlers>
```