### PR TITLE
Add description attribute to all the mediators in Synapse xsd files

### DIFF
--- a/vscode-plugin/synapse-schemas/mediators/advanced/cache.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/advanced/cache.xsd
@@ -71,6 +71,7 @@
             <xs:attribute name="timeout" type="xs:int" use="optional"/>
             <xs:attribute name="collector" type="xs:boolean" use="required"/>
             <xs:attribute name="maxMessageSize" type="xs:int" use="optional"/>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 

--- a/vscode-plugin/synapse-schemas/mediators/advanced/clone.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/advanced/clone.xsd
@@ -46,6 +46,7 @@
             <xs:attribute name="soapAction" type="xs:boolean" use="required"/>
             <xs:attribute name="sequence" type="xs:boolean" use="required"/>
             <xs:attribute name="endpoint" type="xs:boolean" use="required"/>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 

--- a/vscode-plugin/synapse-schemas/mediators/advanced/db_mediators.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/advanced/db_mediators.xsd
@@ -102,6 +102,7 @@
                 </xs:complexType>
             </xs:element>
         </xs:all>
+        <xs:attribute name="description" type="xs:string" use="optional"/>
     </xs:complexType>
 
     <xs:group name="defined-db-connection">

--- a/vscode-plugin/synapse-schemas/mediators/advanced/enqueue.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/advanced/enqueue.xsd
@@ -32,6 +32,7 @@
             <xs:attribute name="priority" type="xs:integer" use="required"/>
             <xs:attribute name="sequence" type="xs:string" use="required"/>
             <xs:attribute name="executor" type="xs:string" use="required"/>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 

--- a/vscode-plugin/synapse-schemas/mediators/advanced/event.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/advanced/event.xsd
@@ -31,6 +31,7 @@
         <xs:complexType>
             <xs:attribute name="topic" type="xs:string" use="required"/>
             <xs:attribute name="expression" type="xs:string" use="optional"/>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 

--- a/vscode-plugin/synapse-schemas/mediators/advanced/transaction.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/advanced/transaction.xsd
@@ -42,6 +42,7 @@
                     </xs:restriction>
                 </xs:simpleType>
             </xs:attribute>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 

--- a/vscode-plugin/synapse-schemas/mediators/core/call-template.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/core/call-template.xsd
@@ -37,6 +37,7 @@
     <xs:complexType name="WithParam">
         <xs:attribute name="name" type="xs:string" use="required"/>
         <xs:attribute name="value" type="xs:string" use="required"/>
+        <xs:attribute name="description" type="xs:string" use="optional"/>
     </xs:complexType>
 
 </xs:schema>

--- a/vscode-plugin/synapse-schemas/mediators/core/call.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/core/call.xsd
@@ -33,6 +33,7 @@
                 <xs:element name="endpoint" type="Endpoint" minOccurs="0" maxOccurs="1"/>
             </xs:sequence>
             <xs:attribute name="blocking" type="xs:boolean" use="optional" default="true"/>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 

--- a/vscode-plugin/synapse-schemas/mediators/core/callout.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/core/callout.xsd
@@ -72,6 +72,7 @@
             <xs:attribute name="action" type="xs:string" use="optional"/>
             <xs:attribute name="initAxis2ClientOptions" type="xs:boolean" use="optional"/>
             <xs:attribute name="endpointKey" type="xs:string" use="optional"/>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 

--- a/vscode-plugin/synapse-schemas/mediators/core/drop.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/core/drop.xsd
@@ -28,6 +28,9 @@
                 Drops the current message that is being process, and terminates the message flow.
             </xs:documentation>
         </xs:annotation>
+        <xs:complexType>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
+        </xs:complexType>
     </xs:element>
 
 </xs:schema>

--- a/vscode-plugin/synapse-schemas/mediators/core/header.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/core/header.xsd
@@ -45,6 +45,7 @@
                     </xs:restriction>
                 </xs:simpleType>
             </xs:attribute>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 

--- a/vscode-plugin/synapse-schemas/mediators/core/log.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/core/log.xsd
@@ -39,6 +39,7 @@
             <xs:attribute name="level" type="logLevel" use="required"/>
             <xs:attribute name="separator" type="xs:string" use="optional" default=", "/>
             <xs:attribute name="category" type="logCategory" use="optional" default="INFO"/>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 

--- a/vscode-plugin/synapse-schemas/mediators/core/loopback.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/core/loopback.xsd
@@ -26,6 +26,9 @@
                 the inflow that are placed after the Loopback mediator are skipped.
             </xs:documentation>
         </xs:annotation>
+        <xs:complexType>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
+        </xs:complexType>
     </xs:element>
 
 </xs:schema>

--- a/vscode-plugin/synapse-schemas/mediators/core/property.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/core/property.xsd
@@ -49,6 +49,7 @@
             <xs:attribute name="type" type="xs:string" use="optional"/>
             <xs:attribute name="pattern" type="xs:string" use="optional"/>
             <xs:attribute name="group" type="xs:int" use="optional"/>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 

--- a/vscode-plugin/synapse-schemas/mediators/core/respond.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/core/respond.xsd
@@ -25,6 +25,9 @@
                 Terminates the processing of the current message flow and returns the message to the client.
             </xs:documentation>
         </xs:annotation>
+        <xs:complexType>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
+        </xs:complexType>
     </xs:element>
 
 </xs:schema>

--- a/vscode-plugin/synapse-schemas/mediators/core/send.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/core/send.xsd
@@ -36,8 +36,8 @@
                 <xs:element name="endpoint" type="Endpoint" minOccurs="0" maxOccurs="1"/>
             </xs:sequence>
             <xs:attribute name="receive" type="xs:string" use="optional"/>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 
 </xs:schema>
-

--- a/vscode-plugin/synapse-schemas/mediators/core/store.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/core/store.xsd
@@ -30,6 +30,7 @@
         <xs:complexType>
             <xs:attribute name="messageStore" type="xs:string" use="required"/>
             <xs:attribute name="sequence" type="xs:string" use="optional"/>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 

--- a/vscode-plugin/synapse-schemas/mediators/core/validate.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/core/validate.xsd
@@ -59,6 +59,7 @@
                 <xs:element name="property" type="mediatorProperty" minOccurs="0" maxOccurs="unbounded"/>
             </xs:sequence>
             <xs:attribute name="source" type="xs:string" use="optional"/>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 

--- a/vscode-plugin/synapse-schemas/mediators/eip/aggregate.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/eip/aggregate.xsd
@@ -59,6 +59,7 @@
                     </xs:complexType>
                 </xs:element>
             </xs:choice>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 

--- a/vscode-plugin/synapse-schemas/mediators/eip/foreach.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/eip/foreach.xsd
@@ -39,6 +39,7 @@
             <xs:attribute name="expression" type="xs:string" use="required"/>
             <xs:attribute name="sequence" type="xs:string" use="optional"/>
             <xs:attribute name="id" type="xs:string" use="optional"/>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 

--- a/vscode-plugin/synapse-schemas/mediators/eip/iterate.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/eip/iterate.xsd
@@ -41,6 +41,7 @@
             <xs:attribute name="expression" type="xs:string" use="required"/>
             <xs:attribute name="preservePayload" type="xs:boolean" use="optional"/>
             <xs:attribute name="attachPath" type="xs:string" use="optional"/>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 

--- a/vscode-plugin/synapse-schemas/mediators/extension/bean.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/extension/bean.xsd
@@ -40,6 +40,7 @@
             <xs:attribute name="class" type="xs:string" use="optional"/>
             <xs:attribute name="property" type="xs:string" use="required"/>
             <xs:attribute name="value" type="xs:string" use="required"/>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 

--- a/vscode-plugin/synapse-schemas/mediators/extension/class.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/extension/class.xsd
@@ -35,6 +35,7 @@
                 <xs:element name="property" type="mediatorProperty" minOccurs="0" maxOccurs="unbounded"/>
             </xs:sequence>
             <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 

--- a/vscode-plugin/synapse-schemas/mediators/extension/command.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/extension/command.xsd
@@ -53,6 +53,7 @@
                 </xs:element>
             </xs:sequence>
             <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 

--- a/vscode-plugin/synapse-schemas/mediators/extension/ejb.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/extension/ejb.xsd
@@ -47,6 +47,7 @@
             <xs:attribute name="method" type="xs:string" use="optional"/>
             <xs:attribute name="target" type="xs:string" use="optional"/>
             <xs:attribute name="jndiName" type="xs:string" use="optional"/>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 

--- a/vscode-plugin/synapse-schemas/mediators/extension/script.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/extension/script.xsd
@@ -43,6 +43,7 @@
             </xs:attribute>
             <xs:attribute name="key" type="xs:string" use="optional"/>
             <xs:attribute name="function" type="xs:string" use="optional"/>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 

--- a/vscode-plugin/synapse-schemas/mediators/extension/spring.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/extension/spring.xsd
@@ -31,6 +31,7 @@
         <xs:complexType>
             <xs:attribute name="bean" use="required" type="xs:string"/>
             <xs:attribute name="key" type="xs:string" use="optional"/>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 

--- a/vscode-plugin/synapse-schemas/mediators/filter/cond_router.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/filter/cond_router.xsd
@@ -52,6 +52,7 @@
                 </xs:element>
             </xs:sequence>
             <xs:attribute name="continueAfter" type="xs:boolean" use="optional" default="false"/>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 

--- a/vscode-plugin/synapse-schemas/mediators/filter/filter.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/filter/filter.xsd
@@ -59,6 +59,7 @@
             <xs:attribute name="source" type="xs:string" use="optional"/>
             <xs:attribute name="regex" type="xs:string" use="optional"/>
             <xs:attribute name="xpath" type="xs:string" use="optional"/>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 

--- a/vscode-plugin/synapse-schemas/mediators/filter/switch.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/filter/switch.xsd
@@ -59,6 +59,7 @@
                 </xs:element>
             </xs:sequence>
             <xs:attribute name="source" type="xs:string" use="optional"/>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 

--- a/vscode-plugin/synapse-schemas/mediators/filter/throttle.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/filter/throttle.xsd
@@ -60,6 +60,7 @@
             <xs:attribute name="id" type="xs:string" use="required"/>
             <xs:attribute name="onAccept" type="xs:string" use="optional"/>
             <xs:attribute name="onReject" type="xs:string" use="optional"/>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 

--- a/vscode-plugin/synapse-schemas/mediators/other/bam.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/other/bam.xsd
@@ -41,6 +41,7 @@
                     </xs:complexType>
                 </xs:element>
             </xs:sequence>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 

--- a/vscode-plugin/synapse-schemas/mediators/other/builder.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/other/builder.xsd
@@ -36,6 +36,7 @@
                     </xs:complexType>
                 </xs:element>
             </xs:sequence>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 

--- a/vscode-plugin/synapse-schemas/mediators/other/entitlement.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/other/entitlement.xsd
@@ -82,6 +82,7 @@
                     </xs:restriction>
                 </xs:simpleType>
             </xs:attribute>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 

--- a/vscode-plugin/synapse-schemas/mediators/other/oauth.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/other/oauth.xsd
@@ -30,6 +30,7 @@
             <xs:attribute name="remoteServiceUrl" type="xs:string" use="required"/>
             <xs:attribute name="username" type="xs:string" use="optional"/>
             <xs:attribute name="password" type="xs:string" use="optional"/>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 

--- a/vscode-plugin/synapse-schemas/mediators/other/publishEvent.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/other/publishEvent.xsd
@@ -74,6 +74,7 @@
                     </xs:complexType>
                 </xs:element>
             </xs:sequence>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 

--- a/vscode-plugin/synapse-schemas/mediators/other/rule.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/other/rule.xsd
@@ -101,6 +101,7 @@
                     </xs:complexType>
                 </xs:element>
             </xs:sequence>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 

--- a/vscode-plugin/synapse-schemas/mediators/transformation/datamapper.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/transformation/datamapper.xsd
@@ -31,6 +31,7 @@
             <xs:attribute name="outputSchema" type="xs:string" use="required"/>
             <xs:attribute name="inputType" type="SchemaType" use="required"/>
             <xs:attribute name="outputType" type="SchemaType" use="required"/>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 

--- a/vscode-plugin/synapse-schemas/mediators/transformation/enrich.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/transformation/enrich.xsd
@@ -32,6 +32,7 @@
                 <xs:element name="source" type="SourceEnrich" minOccurs="1" maxOccurs="1"/>
                 <xs:element name="target" type="TargetEnrich" minOccurs="1" maxOccurs="1"/>
             </xs:all>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 

--- a/vscode-plugin/synapse-schemas/mediators/transformation/fastXSLT.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/transformation/fastXSLT.xsd
@@ -28,6 +28,7 @@
         </xs:annotation>
         <xs:complexType>
             <xs:attribute name="key" type="xs:string" use="required"/>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 

--- a/vscode-plugin/synapse-schemas/mediators/transformation/fault.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/transformation/fault.xsd
@@ -65,6 +65,7 @@
                     </xs:restriction>
                 </xs:simpleType>
             </xs:attribute>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 

--- a/vscode-plugin/synapse-schemas/mediators/transformation/payload.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/transformation/payload.xsd
@@ -59,6 +59,7 @@
                     </xs:restriction>
                 </xs:simpleType>
             </xs:attribute>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 

--- a/vscode-plugin/synapse-schemas/mediators/transformation/rewrite.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/transformation/rewrite.xsd
@@ -79,6 +79,7 @@
             </xs:sequence>
             <xs:attribute name="inProperty" use="optional" type="xs:string"/>
             <xs:attribute name="outProperty" use="optional" type="xs:string"/>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 

--- a/vscode-plugin/synapse-schemas/mediators/transformation/smooks.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/transformation/smooks.xsd
@@ -57,6 +57,7 @@
                 </xs:element>
             </xs:sequence>
             <xs:attribute name="config-key" type="xs:string" use="optional"/>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 

--- a/vscode-plugin/synapse-schemas/mediators/transformation/xquery.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/transformation/xquery.xsd
@@ -61,6 +61,7 @@
             </xs:sequence>
             <xs:attribute name="key" use="required" type="xs:string"/>
             <xs:attribute name="target" use="optional" type="xs:string"/>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 

--- a/vscode-plugin/synapse-schemas/mediators/transformation/xslt.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/transformation/xslt.xsd
@@ -49,6 +49,7 @@
             </xs:sequence>
             <xs:attribute name="key" use="required" type="xs:string"/>
             <xs:attribute name="source" type="xs:string" use="optional"/>
+            <xs:attribute name="description" type="xs:string" use="optional"/>
         </xs:complexType>
     </xs:element>
 


### PR DESCRIPTION
## Purpose
This PR adds the *description* attribute to all the mediators in Synapse xsd files.

Fix https://github.com/wso2/ei-tooling-vscode/issues/17