### PR TITLE
Fix xsd validations for call-template Mediator

### DIFF
--- a/vscode-plugin/synapse-schemas/mediators/core/call-template.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/core/call-template.xsd
@@ -28,7 +28,7 @@
         </xs:annotation>
         <xs:complexType>
             <xs:sequence>
-                <xs:element name="with-param" type="WithParam" minOccurs="1" maxOccurs="unbounded"/>
+                <xs:element name="with-param" type="WithParam" minOccurs="0" maxOccurs="unbounded"/>
             </xs:sequence>
             <xs:attribute name="target" type="xs:string" use="required"/>
         </xs:complexType>


### PR DESCRIPTION
## Purpose
This commit fixes incorrect call-template mediator validations that occur when you don't use the child elements with-param. because with-param isn't required.

## Goals
solves the following error message:
![call-template-mediator-validation](https://user-images.githubusercontent.com/24434503/70142135-da357d00-1698-11ea-869e-8ac363c31036.PNG)
