### PR TITLE
Update template artifact type, modify endpoint.xsd, and upgrade esb-project-archetype version.

### DIFF
--- a/vscode-plugin/src/archetype/archetypeUtils.ts
+++ b/vscode-plugin/src/archetype/archetypeUtils.ts
@@ -20,4 +20,4 @@ export const GROUP_ID_PREFIX: string = "com.example.";
 
 export const ARCHETYPE_ARTIFACT_ID: string = "org.wso2.carbon.extension.esb.project-archetype";
 export const ARCHETYPE_GROUP_ID: string = "org.wso2.carbon.extension.archetype";
-export const ARCHETYPE_VERSION: string = "2.0.11";
+export const ARCHETYPE_VERSION: string = "2.0.13";

--- a/vscode-plugin/src/artifacts/artifactResolver.ts
+++ b/vscode-plugin/src/artifacts/artifactResolver.ts
@@ -172,9 +172,8 @@ export async function createArtifact(artifactType: string) {
                 }
 
                 if (artifactName) {
-                    let type = TemplateArtifactInfo.getType(selectedArtifactType);
                     ArtifactModule.createArtifact(TemplateArtifactInfo.DESTINATION_FOLDER, selectedArtifactType,
-                                                  artifactName.trim(), artifactType, type);
+                                                  artifactName.trim(), artifactType, TemplateArtifactInfo.TYPE);
                 }
             }
             break;

--- a/vscode-plugin/src/artifacts/artifactUtils.ts
+++ b/vscode-plugin/src/artifacts/artifactUtils.ts
@@ -170,6 +170,7 @@ export class TemplateArtifactInfo {
     static readonly PLACEHOLDER: string = "Select an Template Artifact Creation Option...";
     static readonly PROMPT_MESSAGE: string = "Enter Template artifact name...";
     static readonly DESTINATION_FOLDER: string = "templates";
+    static readonly TYPE: string = "synapse/template";
 
     static readonly SEQUENCE: string = "SequenceTemplate";
     static readonly ADDRESS_ENDPOINT: string = "AddressEndpointTemplate";
@@ -182,26 +183,6 @@ export class TemplateArtifactInfo {
     static readonly DEFAULT_ENDPOINT_LABEL: string = "Default Endpoint Template";
     static readonly WSDL_ENDPOINT_LABEL: string = "WSDL Endpoint Template";
     static readonly HTTP_ENDPOINT_LABEL: string = "HTTP Endpoint Template";
-
-    static readonly SEQUENCE_TYPE: string = "synapse/sequenceTemplate";
-    static readonly ADDRESS_ENDPOINT_TYPE: string = "synapse/endpointTemplate";
-    static readonly DEFAULT_ENDPOINT_TYPE: string = "synapse/endpointTemplate";
-    static readonly WSDL_ENDPOINT_TYPE: string = "synapse/sequenceTemplate";
-    static readonly HTTP_ENDPOINT_TYPE: string = "synapse/sequenceTemplate";
-
-    public static getType(templateType: string): string {
-        switch (templateType) {
-            case TemplateArtifactInfo.ADDRESS_ENDPOINT: {
-                return TemplateArtifactInfo.ADDRESS_ENDPOINT_TYPE;
-            }
-            case TemplateArtifactInfo.DEFAULT_ENDPOINT: {
-                return TemplateArtifactInfo.DEFAULT_ENDPOINT_TYPE;
-            }
-            default: {
-                return TemplateArtifactInfo.SEQUENCE_TYPE;
-            }
-        }
-    }
 }
 
 export class SequenceArtifactInfo {

--- a/vscode-plugin/synapse-schemas/endpoint.xsd
+++ b/vscode-plugin/synapse-schemas/endpoint.xsd
@@ -285,7 +285,7 @@
                 <xs:complexType>
                     <xs:all>
                         <xs:element name="duration" minOccurs="0" maxOccurs="1" type="xs:long"/>
-                        <xs:element name="action" minOccurs="0" maxOccurs="1">
+                        <xs:element name="responseAction" minOccurs="0" maxOccurs="1" default="discard">
                             <xs:simpleType>
                                 <xs:restriction base="xs:string">
                                     <xs:enumeration value="discard"/>


### PR DESCRIPTION
## Purpose

- Change template artifact type as synapse/template in the artifact.xml file that is being created in the .car file for each template artifact. Related issue https://github.com/wso2/ei-tooling-vscode/issues/31
- Modify the endpoint.xsd file to have "responseAction" element inside the "timeout" element.
- Upgrade esb-project-archetype version to 2.0.13. Related PR https://github.com/wso2-extensions/archetypes/pull/27

