### PR TITLE
Fix artifacts not getting created issue

### DIFF
--- a/vscode-plugin/package.json
+++ b/vscode-plugin/package.json
@@ -3,7 +3,7 @@
 	"displayName": "WSO2 Enterprise Integrator",
 	"description": "VSCode extension for WSO2 Enterprise Integrator",
 	"publisher": "WSO2",
-	"version": "0.6.0",
+	"version": "0.7.1",
 	"engines": {
 		"vscode": "^1.31.0"
 	},


### PR DESCRIPTION
## Purpose
Before this PR,  the artifacts such as APIs, Endpoints,  etc were not getting created either from the command palette or directly by right-clicking on the project explorer due to the fix done in https://github.com/wso2/ei-tooling-vscode/pull/34.

This PR fixes this issue.