### PR TITLE
Upgrade esb-project-archetype version to 2.0.16

### DIFF
--- a/vscode-plugin/src/archetype/archetypeUtils.ts
+++ b/vscode-plugin/src/archetype/archetypeUtils.ts
@@ -20,4 +20,4 @@ export const GROUP_ID_PREFIX: string = "com.example.";
 
 export const ARCHETYPE_ARTIFACT_ID: string = "org.wso2.carbon.extension.esb.project-archetype";
 export const ARCHETYPE_GROUP_ID: string = "org.wso2.carbon.extension.archetype";
-export const ARCHETYPE_VERSION: string = "2.0.13";
+export const ARCHETYPE_VERSION: string = "2.0.16";


### PR DESCRIPTION
## Purpose
Upgrade esb-project-archetype version to 2.0.16

## Related PR
https://github.com/wso2-extensions/archetypes/pull/30