### PR TITLE
Add Missing Schema Location for WS-Policy

### DIFF
--- a/vscode-plugin/synapse-schemas/mediators/filter/throttle.xsd
+++ b/vscode-plugin/synapse-schemas/mediators/filter/throttle.xsd
@@ -24,7 +24,9 @@
         targetNamespace="http://ws.apache.org/ns/synapse" 
         xmlns="http://ws.apache.org/ns/synapse">
 
-    <xs:import namespace="http://schemas.xmlsoap.org/ws/2004/09/policy" />
+    <xs:import
+        namespace="http://schemas.xmlsoap.org/ws/2004/09/policy"
+        schemaLocation="http://schemas.xmlsoap.org/ws/2004/09/policy/ws-policy.xsd"/>
 
 
     <xs:include schemaLocation="../mediators.xsd" />


### PR DESCRIPTION
## Purpose

Fixes the `throttle.xsd(44, 45): src-resolve: Cannot resolve the name 'wsp:Policy' to a(n) 'element declaration' component.` error.