### PR TITLE
Enable Mediator XSD Support for VsCode XML Extension

### DIFF
--- a/vscode-plugin/synapse-schemas/synapse_config.xsd
+++ b/vscode-plugin/synapse-schemas/synapse_config.xsd
@@ -35,6 +35,7 @@
     <xs:include schemaLocation="task.xsd" />
     <xs:include schemaLocation="template.xsd" />
     <xs:include schemaLocation="registry.xsd" />
+    <xs:include schemaLocation="mediators/mediators.xsd" />
 
     <xs:element name="definitions" type="Definition">
         <xs:annotation>
@@ -68,4 +69,3 @@
         </xs:choice>
     </xs:complexType>
 </xs:schema>
-


### PR DESCRIPTION
## Purpose

Includes the mediator xsd at the top level because otherwise the vscode xml plugin would not download the mediators XSDs resulting in no support for any mediator, e.g. payload factory, log, filter.

## How to Use

- Install the [Vscode XML extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-xml)
- Add the following to your `.vscode/settings.json`:
```json
 "xml.fileAssociations": [
    {
            "pattern": "**/synapse-config/**/*.xml",
            "systemId": "https://raw.githubusercontent.com/integon/ei-tooling-vscode/develop/vscode-plugin/synapse-schemas/synapse_config.xsd"
    }
]
```