### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# See: https://help.github.com/articles/about-codeowners/
+
+# These owners will be the default owners for everything in the repo.
+*       @rosensilva


### PR DESCRIPTION
## Purpose
> The purpose of the following change would be to provide a clear indication in relation to the naming conventions associated to the creation of a WSO2 ESB project
> Add missing onCommand extensions as some of the services are not available per default.
> Refactored some naming conventions as they were too abstract.

## Goals
> This specific feature would provide the user/developer with the ability to clearly define and name the artifactId as well as the ability to provide a groupId associated to the WSO2 ESB project.