### PR TITLE
Add new issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+- name: '📚 Create an Issue'
+  about: Create an issue if something does not work as expected or suggest new functionality/improvements to the product suite.
+  url: https://github.com/wso2/micro-integrator/issues/new/choose
+- name: Chat on help-micro-integrator Discord Channel
+  url: https://discord.com/invite/Xa5VubmThw
+  about: "Chat about anything else with the community."


### PR DESCRIPTION
## Purpose
> The purpose of the following change would be to provide a clear indication in relation to the naming conventions associated to the creation of a WSO2 ESB project
> Add missing onCommand extensions as some of the services are not available per default.
> Refactored some naming conventions as they were too abstract.

## Goals
> This specific feature would provide the user/developer with the ability to clearly define and name the artifactId as well as the ability to provide a groupId associated to the WSO2 ESB project.